### PR TITLE
Better sortedness of extra patterns

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -185,9 +185,6 @@ fn bench_patterns<T: Ord + std::fmt::Debug>(
 
     // Custom patterns designed to find worst case performance.
     let mut extra_pattern_providers: Vec<(&'static str, fn(usize) -> Vec<i32>)> = vec![
-        ("saws_long", |len| {
-            patterns::saw_mixed(len, ((len as f64).log2().round()) as usize)
-        }),
         ("random_d20_start_block", |len| {
             let mut v = patterns::random_uniform(len, 0..20);
             let loop_end = std::cmp::min(len, 100);
@@ -272,11 +269,14 @@ fn bench_patterns<T: Ord + std::fmt::Debug>(
 
             shuffle_vec(v)
         }),
-        ("ascending_saw", |len| {
-            patterns::ascending_saw(len, ((len as f64).log2().round()) as usize)
+        ("saw_ascending", |len| {
+            patterns::saw_ascending(len, ((len as f64).log2().round()) as usize)
         }),
-        ("descending_saw", |len| {
-            patterns::descending_saw(len, ((len as f64).log2().round()) as usize)
+        ("saw_descending", |len| {
+            patterns::saw_descending(len, ((len as f64).log2().round()) as usize)
+        }),
+        ("saws_long", |len| {
+            patterns::saw_mixed(len, ((len as f64).log2().round()) as usize)
         }),
         ("pipe_organ", patterns::pipe_organ),
         ("random__div3", |len| {

--- a/sort_test_tools/src/patterns.rs
+++ b/sort_test_tools/src/patterns.rs
@@ -97,7 +97,7 @@ pub fn descending(size: usize) -> Vec<i32> {
     (0..size as i32).rev().collect::<Vec<_>>()
 }
 
-pub fn ascending_saw(size: usize, saw_count: usize) -> Vec<i32> {
+pub fn saw_ascending(size: usize, saw_count: usize) -> Vec<i32> {
     //   .:  .:
     // .:::.:::
 
@@ -115,7 +115,7 @@ pub fn ascending_saw(size: usize, saw_count: usize) -> Vec<i32> {
     vals
 }
 
-pub fn descending_saw(size: usize, saw_count: usize) -> Vec<i32> {
+pub fn saw_descending(size: usize, saw_count: usize) -> Vec<i32> {
     // :.  :.
     // :::.:::.
 

--- a/sort_test_tools/src/tests.rs
+++ b/sort_test_tools/src/tests.rs
@@ -369,15 +369,15 @@ pub fn descending<S: Sort>() {
     test_impl::<i32, S>(patterns::descending);
 }
 
-pub fn ascending_saw<S: Sort>() {
+pub fn saw_ascending<S: Sort>() {
     test_impl::<i32, S>(|test_size| {
-        patterns::ascending_saw(test_size, ((test_size as f64).log2().round()) as usize)
+        patterns::saw_ascending(test_size, ((test_size as f64).log2().round()) as usize)
     });
 }
 
-pub fn descending_saw<S: Sort>() {
+pub fn saw_descending<S: Sort>() {
     test_impl::<i32, S>(|test_size| {
-        patterns::descending_saw(test_size, ((test_size as f64).log2().round()) as usize)
+        patterns::saw_descending(test_size, ((test_size as f64).log2().round()) as usize)
     });
 }
 
@@ -1239,11 +1239,11 @@ macro_rules! instantiate_sort_tests {
             $sort_impl,
             [miri_no, all_equal],
             [miri_yes, ascending],
-            [miri_no, ascending_saw],
+            [miri_no, saw_ascending],
             [miri_yes, basic],
             [miri_yes, comp_panic],
             [miri_yes, descending],
-            [miri_no, descending_saw],
+            [miri_no, saw_descending],
             [miri_yes, dyn_val],
             [miri_yes, fixed_seed],
             [miri_yes, int_edge],

--- a/util/graph_bench_result/comp_count.py
+++ b/util/graph_bench_result/comp_count.py
@@ -16,6 +16,8 @@ from bokeh.embed import file_html
 from bokeh.palettes import Colorblind
 from bokeh.models import FactorRange, LabelSet
 
+from natsort import natsorted
+
 TRANSFORMS = ["i32", "u64", "string", "1k", "f128"]
 
 
@@ -127,7 +129,7 @@ def plot_single_size(ty, test_size, values):
     comp_counts = []
     comp_counts_full = []
     colors = []
-    for pattern, val in sorted(values.items()):
+    for pattern, val in natsorted(values.items()):
         for sort_name, comp_count in sorted(
             val.items(), key=lambda x: x[1], reverse=True
         ):
@@ -255,7 +257,7 @@ def plot_comparison_evolution_single(sort_names, groups, sort_name):
                     pattern
                 )
 
-    for pattern, data in sorted(pattern_comp_counts.items()):
+    for pattern, data in natsorted(pattern_comp_counts.items()):
         source = ColumnDataSource(data=data)
         color = map_pattern_to_color(pattern)
 

--- a/util/graph_bench_result/direct_versus.py
+++ b/util/graph_bench_result/direct_versus.py
@@ -13,6 +13,8 @@ from bokeh.resources import CDN
 from bokeh.embed import file_html
 from bokeh.palettes import Colorblind
 
+from natsort import natsorted
+
 from cpu_info import get_cpu_info
 from util import parse_result, extract_groups
 
@@ -94,7 +96,7 @@ def extract_line(sort_name_a, sort_name_b, pattern, values):
 
 
 def plot_versus(sort_name_a, sort_name_b, ty, prediction_state, values):
-    patterns = sorted(list(values.values())[0].keys())
+    patterns = natsorted(list(values.values())[0].keys())
     min_test_size = min(values.keys())
     max_test_size = max(values.keys())
 

--- a/util/graph_bench_result/requirements.txt
+++ b/util/graph_bench_result/requirements.txt
@@ -1,6 +1,7 @@
 bokeh==2.4.3
 Jinja2==3.1.2
 MarkupSafe==2.1.1
+natsort==8.4.0
 numpy==1.23.2
 packaging==21.3
 Pillow==9.2.0

--- a/util/graph_bench_result/single_size.py
+++ b/util/graph_bench_result/single_size.py
@@ -12,6 +12,8 @@ from bokeh.resources import CDN
 from bokeh.embed import file_html
 from bokeh.models import FactorRange, LabelSet
 
+from natsort import natsorted
+
 from cpu_info import get_cpu_info
 from util import parse_result, extract_groups, build_color_palette
 
@@ -77,7 +79,7 @@ def plot_single_size(ty, prediction_state, test_size, values):
     y = []
     bench_times = []
     colors = []
-    for pattern, val in reversed(sorted(values.items())):
+    for pattern, val in reversed(natsorted(values.items())):
         for sort_name, bench_times_ns in sorted(
             val.items(), key=lambda x: x[1], reverse=True
         ):

--- a/util/graph_bench_result/util.py
+++ b/util/graph_bench_result/util.py
@@ -37,12 +37,6 @@ def extract_groups(bench_result):
         if sort_name == "c_fluxsort_stable" and ty not in ("u64", "i32"):
             continue
 
-        if "_stable" in sort_name:
-            continue  # TODO graph all.
-
-        # if "radix" in sort_name:
-        #     continue
-
         bench_time_ns = value["criterion_estimates_v1"]["median"][
             "point_estimate"
         ]


### PR DESCRIPTION
Using natsort keeps patterns like `random_p1`, `random_p15`, `random_p2` in the correct order instead of lexicographically sorting them.
Renaming `ascending_saw` to `saw_ascending` and descending_saw` to `saw_descending` groups the "saw" patterns together.