### PR TITLE
Create rust-toolchain.toml for auto-selecting nightly toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
docs: https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file

This file allows auto-selection of the correct toolchain when using rustup. Nice to have for anyone cloning and running this.