### PR TITLE
Add rayon parallel sort benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 .gdb_history
 .vscode
+/analysis
+/venv
+*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,16 +132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -474,14 +464,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -582,6 +570,7 @@ dependencies = [
  "proc-macro2",
  "radsort",
  "rand",
+ "rayon",
  "regex",
  "sort_test_tools",
  "tiny_sort",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ crumsort = { version = "0.1", optional = true }
 tiny_sort = { version = "1.0", optional = true }
 sort_test_tools = { path = "sort_test_tools", default-features = false }
 ipnsort = { path = "ipnsort", default-features = false }
+rayon = { version = "1.8.0", optional = true }
 
 [dev-dependencies]
 rand = "0.8"
@@ -90,6 +91,7 @@ default = [
     # "rust_glidesort",
     # "rust_crumsort_rs",
     # "rust_tinysort",
+    "rust_rayon_parallel",
 ]
 
 # Enable support for C++ std::sort and std::sort_stable.
@@ -174,6 +176,9 @@ rust_crumsort_rs = ["crumsort"]
 
 # Enable binary-size optimized stable and unstable tiny-sort by Lukas Bergdoll.
 rust_tinysort = ["tiny_sort"]
+
+# Enable rayon paralell sorts
+rust_rayon_parallel = ["rayon"]
 
 # Enable the sort evolution code.
 # Demonstrates various stages and optimizations of stable and unstable sorts.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ default = [
     # "rust_glidesort",
     # "rust_crumsort_rs",
     # "rust_tinysort",
-    "rust_rayon_parallel",
+    # "rust_rayon_parallel",
 ]
 
 # Enable support for C++ std::sort and std::sort_stable.

--- a/benches/modules/sort.rs
+++ b/benches/modules/sort.rs
@@ -134,6 +134,9 @@ pub fn bench<T: Ord + std::fmt::Debug>(
     #[cfg(feature = "rust_tinysort")]
     bench_inst!(stable::rust_tinysort);
 
+    #[cfg(feature = "rust_rayon_parallel")]
+    bench_inst!(stable::rust_rayon_parallel);
+
     // --- Unstable sorts ---
 
     bench_inst!(unstable::rust_ipnsort);

--- a/src/stable/mod.rs
+++ b/src/stable/mod.rs
@@ -33,3 +33,6 @@ pub mod cpp_powersort_4way;
 // Note, this sort is only stable if the the supplied comparison returns less, equal and more.
 #[cfg(feature = "c_fluxsort")]
 pub mod c_fluxsort;
+
+#[cfg(feature = "rust_rayon_parallel")]
+pub mod rust_rayon_parallel;

--- a/src/stable/rust_rayon_parallel.rs
+++ b/src/stable/rust_rayon_parallel.rs
@@ -1,0 +1,45 @@
+use std::cmp::Ordering;
+
+use rayon::slice::ParallelSliceMut;
+
+sort_impl!("rust_rayon_parallel_stable");
+
+trait RayonStableSort: Sized {
+    fn sort(data: &mut [Self]);
+}
+
+impl<T> RayonStableSort for T {
+    default fn sort(_data: &mut [Self]) {
+        panic!("Type not supported.");
+    }
+}
+
+impl<T: Send + Ord> RayonStableSort for T {
+    fn sort(data: &mut [Self]) {
+        data.par_sort();
+    }
+}
+
+trait RayonStableSortBy<F>: Sized {
+    fn sort_by(data: &mut [Self], compare: F);
+}
+
+impl<T, F> RayonStableSortBy<F> for T {
+    default fn sort_by(_data: &mut [T], _compare: F) {
+        panic!("Type not supported.");
+    }
+}
+
+impl<T: Send + Ord, F: Fn(&T, &T) -> Ordering + Send + Sync> RayonStableSortBy<F> for T {
+    fn sort_by(data: &mut [T], compare: F) {
+        data.par_sort_by(compare);
+    }
+}
+
+pub fn sort<T: Ord>(data: &mut [T]) {
+    <T as RayonStableSort>::sort(data);
+}
+
+pub fn sort_by<T, F: FnMut(&T, &T) -> Ordering>(data: &mut [T], compare: F) {
+    <T as RayonStableSortBy<F>>::sort_by(data, compare);
+}

--- a/src/unstable/mod.rs
+++ b/src/unstable/mod.rs
@@ -45,3 +45,6 @@ pub mod cpp_std_libcxx;
 // Call stdlib std::sort sort via FFI.
 #[cfg(feature = "cpp_std_gcc4_3")]
 pub mod cpp_std_gcc4_3;
+
+#[cfg(feature = "rust_rayon_parallel")]
+pub mod rust_rayon_parallel;

--- a/src/unstable/rust_rayon_parallel.rs
+++ b/src/unstable/rust_rayon_parallel.rs
@@ -1,0 +1,45 @@
+use std::cmp::Ordering;
+
+use rayon::slice::ParallelSliceMut;
+
+sort_impl!("rust_rayon_parallel_stable");
+
+trait RayonStableSort: Sized {
+    fn sort(data: &mut [Self]);
+}
+
+impl<T> RayonStableSort for T {
+    default fn sort(_data: &mut [Self]) {
+        panic!("Type not supported.");
+    }
+}
+
+impl<T: Send + Ord> RayonStableSort for T {
+    fn sort(data: &mut [Self]) {
+        data.par_sort_unstable();
+    }
+}
+
+trait RayonStableSortBy<F>: Sized {
+    fn sort_by(data: &mut [Self], compare: F);
+}
+
+impl<T, F> RayonStableSortBy<F> for T {
+    default fn sort_by(_data: &mut [T], _compare: F) {
+        panic!("Type not supported.");
+    }
+}
+
+impl<T: Send + Ord, F: Fn(&T, &T) -> Ordering + Send + Sync> RayonStableSortBy<F> for T {
+    fn sort_by(data: &mut [T], compare: F) {
+        data.par_sort_unstable_by(compare);
+    }
+}
+
+pub fn sort<T: Ord>(data: &mut [T]) {
+    <T as RayonStableSort>::sort(data);
+}
+
+pub fn sort_by<T, F: FnMut(&T, &T) -> Ordering>(data: &mut [T], compare: F) {
+    <T as RayonStableSortBy<F>>::sort_by(data, compare);
+}

--- a/util/graph_bench_result/util.py
+++ b/util/graph_bench_result/util.py
@@ -82,6 +82,7 @@ def build_color_palette():
         "cpp_powersort_4way_stable": palette[7],
         "rust_wpwoodjr_stable": palette[7],
         "rust_tinymergesort_stable": palette[7],
+        "rust_rayon_parallel_stable": palette[7],
         # Unstable
         "c_crumsort_unstable": palette[0],
         "cpp_std_sys_unstable": palette[1],
@@ -95,6 +96,7 @@ def build_color_palette():
         "cpp_ips4o_unstable": palette[6],
         "cpp_blockquicksort": palette[7],
         "rust_tinyheapsort_unstable": palette[7],
+        "rust_rayon_parallel_unstable": palette[7],
         # There are more sorts but they don't really fit the graph or colors at
         # the same time
         "rust_radsort_radix": palette[4],


### PR DESCRIPTION
Adds the parallel sorts from rayon as options to benchmark. They appear to be very similar timsort-like implementations to std, but chunked by rayons parallelism.

I'm not sure if the way i worked around the Rayon item/compare trait bounds is ideal. its mostly adapted from crumsort.

this also adds the required folders to gitingnore, which need to be ignored when comitting after installing the python venv and generating the output.